### PR TITLE
Re-define default parameters (ES6 feature)

### DIFF
--- a/range.js
+++ b/range.js
@@ -127,7 +127,10 @@ $.fn.range = function(parameters) {
 					return Math.round(ratio * $(inner).width()) + $(trackLeft).position().left - offset;
 				},
 
-				setValue: function(newValue, triggeredByUser = true) {
+				setValue: function(newValue, triggeredByUser) {
+					if (typeof triggeredByUser !== 'boolean') {
+						triggeredByUser = true;
+					}
 					if(settings.input) {
 						$(settings.input).val(newValue);
 					}
@@ -192,7 +195,10 @@ $.fn.range = function(parameters) {
 					}
 				},
 				
-				setValuePosition: function(val, triggeredByUser = true) {
+				setValuePosition: function(val, triggeredByUser) {
+					if (typeof triggeredByUser !== 'boolean') {
+						triggeredByUser = true;
+					}
 					var position = module.determinePosition(val);
 					module.setPosition(position);
 					module.setValue(val, triggeredByUser);


### PR DESCRIPTION
Re-define how the default parameters are defined as they're part of the ES6 standard.
Some code minifier like UglifyJS doesn't understand the ES6 syntax yet.